### PR TITLE
Fix frontend sign out logic to resolve empty room issue

### DIFF
--- a/frontend/src/app/state/effects/websocket.ts
+++ b/frontend/src/app/state/effects/websocket.ts
@@ -165,6 +165,11 @@ export class WebSocketEffects {
             obs.next(new WebSocketActions.RawResponse(data));
           }
         });
+        return () => {
+          if (this.socket != null) {
+            this.socket.close();
+          }
+        };
       });
     });
 

--- a/frontend/src/app/state/reducers/user.ts
+++ b/frontend/src/app/state/reducers/user.ts
@@ -57,7 +57,7 @@ export function userReducer(
       return { ...state, authUser: action.user, currentError: null };
     case UserActions.SIGN_IN_FAILED:
       return { ...state, currentError: action.error };
-    case UserActions.SIGN_OUT_DONE:
+    case UserActions.SIGN_OUT_START:
       return { ...state, authUser: null, currentError: null };
     case UserActions.VERIFY_SESSION:
       return { ...state, verifying: true };


### PR DESCRIPTION
Hopefully...

---

* 다른 `Connect` 액션을 받으면 기존 연결을 끊음
* 로그아웃으로 연결이 끊겼을 때 바로 재접속하지 않도록 함