### PR TITLE
Delay protocol setting and gameplay start behaviour

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -23,6 +23,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+USE_DELAY = True if os.environ.get('MIGHTY_USE_DELAY', False) == 'true' else False
+DEAL_DELAY = 2000
+DEAL_MISS_DELAY = 3000
+AI_BID_DELAY = 1000
+AI_SELECT_DELAY = 2500
+AI_TURN_DELAY = 1000
 
 ALLOWED_HOSTS = []
 
@@ -40,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'anymail',
     'channels',
+    'channels.delay',
 ]
 
 ANYMAIL = {

--- a/backend/websocket/consumers/ai.py
+++ b/backend/websocket/consumers/ai.py
@@ -183,9 +183,9 @@ class AI():
         }
         if play_card['rank'] == 'JK':
             if is_president or is_friend:
-                ret['joker-suit'] = giruda
+                ret['joker_suit'] = giruda
             else:
                 suits = ['S', 'D', 'H', 'C']
                 suits.remove(giruda)
-                ret['joker-suit'] = random.choice(suits)
+                ret['joker_suit'] = random.choice(suits)
         return ret

--- a/backend/websocket/consumers/gameplay_consumers.py
+++ b/backend/websocket/consumers/gameplay_consumers.py
@@ -6,6 +6,9 @@ from .consumer_utils import event, reply_error, response, reset_room_data
 from django.core.cache import cache
 from .state import RoomState
 from api.models import User, GameHistory
+from backend.settings import USE_DELAY
+from backend.settings import DEAL_DELAY, DEAL_MISS_DELAY
+from backend.settings import AI_TURN_DELAY, AI_BID_DELAY, AI_SELECT_DELAY
 from random import shuffle
 
 
@@ -54,11 +57,19 @@ def gameplay_start_consumer(message):
             dealed_card = cards[:cards_per_person]
             room['players'][i]['cards'] = dealed_card
 
-            reply_channel = Channel(room['players'][i]['reply'])
             data = {
                 'cards': dealed_card,
             }
-            reply_channel.send(event('gameplay-deal', data))
+            if USE_DELAY:
+                delay = {
+                    'channel': room['players'][i]['reply'],
+                    'delay': DEAL_DELAY,
+                    'content': event('gameplay-deal', data),
+                }
+                Channel('asgi.delay').send(delay, immediately=True)
+            else:
+                reply_channel = Channel(room['players'][i]['reply'])
+                reply_channel.send(event('gameplay-deal', data))
 
             del cards[:cards_per_person]
 
@@ -81,7 +92,15 @@ def gameplay_start_consumer(message):
             build_ai_message(ai, ret)
             ret['room_id'] = room_id
             if 'bid' in ret:
-                Channel('gameplay-bid').send(ret)
+                if USE_DELAY:
+                    delay = {
+                        'channel': 'gameplay-bid',
+                        'delay': AI_BID_DELAY,
+                        'content': ret,
+                    }
+                    Channel('asgi.delay').send(delay, immediately=True)
+                else:
+                    Channel('gameplay-bid').send(ret)
             else:
                 # TODO: deal miss
                 pass
@@ -268,7 +287,15 @@ def gameplay_bid_consumer(message):
                     ret = ai.friend_select(room)
                     build_ai_message(ai, ret)
                     ret['room_id'] = room_id
-                    Channel('gameplay-friend-select').send(ret)
+                    if USE_DELAY:
+                        delay = {
+                            'channel': 'gameplay-friend-select',
+                            'delay': AI_SELECT_DELAY,
+                            'content': ret,
+                        }
+                        Channel('asgi.delay').send(delay, immediately=True)
+                    else:
+                        Channel('gameplay-friend-select').send(ret)
 
                 room['game']['floor_cards'] = []
             elif player_number == 6:
@@ -286,7 +313,15 @@ def gameplay_bid_consumer(message):
                     ret = ai.kill(room)
                     build_ai_message(ai, ret)
                     ret['room_id'] = room_id
-                    Channel('gameplay-kill').send(ret)
+                    if USE_DELAY:
+                        delay = {
+                            'channel': 'gameplay-friend-select',
+                            'delay': AI_SELECT_DELAY,
+                            'content': ret,
+                        }
+                        Channel('asgi.delay').send(delay, immediately=True)
+                    else:
+                        Channel('gameplay-friend-select').send(ret)
 
             cache.set('room:' + room_id, room)
             return
@@ -338,7 +373,15 @@ def gameplay_bid_consumer(message):
         build_ai_message(ai, ret)
         ret['room_id'] = room_id
         if 'bid' in ret:
-            Channel('gameplay-bid').send(ret)
+            if USE_DELAY:
+                delay = {
+                    'channel': 'gameplay-bid',
+                    'delay': AI_BID_DELAY,
+                    'content': ret,
+                }
+                Channel('asgi.delay').send(delay, immediately=True)
+            else:
+                Channel('gameplay-bid').send(ret)
         else:
             # TODO: deal miss
             pass
@@ -555,7 +598,15 @@ def gameplay_kill_consumer(message):
                         build_ai_message(ai, ret)
                         ret['room_id'] = room_id
                         if 'bid' in ret:
-                            Channel('gameplay-bid').send(ret)
+                            if USE_DELAY:
+                                delay = {
+                                    'channel': 'gameplay-bid',
+                                    'delay': AI_BID_DELAY,
+                                    'content': ret,
+                                }
+                                Channel('asgi.delay').send(delay, immediately=True)
+                            else:
+                                Channel('gameplay-bid').send(ret)
                         else:
                             pass
                     return
@@ -823,7 +874,15 @@ def gameplay_friend_select_consumer(message):
         ret = ai.play(room)
         build_ai_message(ai, ret)
         ret['room_id'] = room_id
-        Channel('gameplay-play').send(ret)
+        if USE_DELAY:
+            delay = {
+                'channel': 'gameplay-play',
+                'delay': AI_TURN_DELAY,
+                'content': ret,
+            }
+            Channel('asgi.delay').send(delay, immediately=True)
+        else:
+            Channel('gameplay-play').send(ret)
 
 
 def gameplay_play_consumer(message):
@@ -1129,7 +1188,15 @@ def gameplay_play_consumer(message):
         ret = ai.play(room)
         build_ai_message(ai, ret)
         ret['room_id'] = room_id
-        Channel('gameplay-play').send(ret)
+        if USE_DELAY:
+            delay = {
+                'channel': 'gameplay-play',
+                'delay': AI_TURN_DELAY,
+                'content': ret,
+            }
+            Channel('asgi.delay').send(delay, immediately=True)
+        else:
+            Channel('gameplay-play').send(ret)
 
 
 def gameplay_continue_consumer(message):

--- a/backend/websocket/consumers/room_consumers.py
+++ b/backend/websocket/consumers/room_consumers.py
@@ -289,7 +289,6 @@ def room_start_consumer(message):
         cache.set(room_cache_key, room_cache)
 
         reply_channel.send(response({}, nonce=nonce))
-        Group(room_id).send(event('room-start', {}))
 
         # yeah, start it!
         Channel('gameplay-start').send({'room_id': room_id})

--- a/backend/websocket/test_gameplay.py
+++ b/backend/websocket/test_gameplay.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from channels.test import ChannelTestCase, Client
 from django.core.cache import cache
 from websocket.consumers.card import win_card, code_to_card
@@ -10,6 +10,7 @@ from api.models import User, GameHistory, create_user
 import os
 
 
+@override_settings(USE_DELAY=False)
 class AITest(TestCase):
     def setUp(self):
         self.mock_room = new_room_data(
@@ -138,6 +139,7 @@ class AITest(TestCase):
         self.assertEqual(card['suit'], 'C')
 
 
+@override_settings(USE_DELAY=False)
 class GameplayTest(ChannelTestCase):
     def setUp(self):
         cache.clear()

--- a/backend/websocket/test_room.py
+++ b/backend/websocket/test_room.py
@@ -1,3 +1,4 @@
+from django.test import override_settings
 from channels.test import ChannelTestCase, WSClient
 from websocket.consumers.consumer_utils import request
 from websocket.consumers.room_consumers import room_join_consumer
@@ -16,6 +17,7 @@ from websocket.consumers.state import RoomState
 import os
 
 
+@override_settings(USE_DELAY=False)
 class RoomJoinTest(ChannelTestCase):
     def setUp(self):
         cache.clear()
@@ -219,6 +221,7 @@ class RoomJoinTest(ChannelTestCase):
         self.assertEqual(response['error']['reason'], 'Room is full')
 
 
+@override_settings(USE_DELAY=False)
 class RoomLeaveTest(ChannelTestCase):
     def setUp(self):
         cache.clear()
@@ -342,6 +345,7 @@ class RoomLeaveTest(ChannelTestCase):
         self.assertFalse(Room.objects.filter(room_id='room').exists())
 
 
+@override_settings(USE_DELAY=False)
 class RoomReadyTest(ChannelTestCase):
     def setUp(self):
         cache.clear()
@@ -431,6 +435,7 @@ class RoomReadyTest(ChannelTestCase):
         self.assertFalse(room_cache['players'][0]['ready'])
 
 
+@override_settings(USE_DELAY=False)
 class RoomStartTest(ChannelTestCase):
     def setUp(self):
         cache.clear()
@@ -540,6 +545,7 @@ class RoomStartTest(ChannelTestCase):
         response = client1.receive()
         self.assertTrue(response['success'])
 
+        client1.consume('gameplay-start')
         response = client1.receive()
         self.assertEqual(response['event'], 'room-start')
 
@@ -547,6 +553,7 @@ class RoomStartTest(ChannelTestCase):
         self.assertEqual(response['event'], 'room-start')
 
 
+@override_settings(USE_DELAY=False)
 class RoomResetTest(ChannelTestCase):
     def setUp(self):
         cache.clear()


### PR DESCRIPTION
- Set Environment variable `$MIGHTY_USE_DELAY=true` to use delay protocol
- You have to run delay server by `python manage.py rundelay` (also runserver)
- `room-start` event now delivers room data
- maybe you have to migrate by `python manage.py migrate`